### PR TITLE
Feat:Add settings page

### DIFF
--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -12,14 +12,14 @@
  */
 function rt_settings_init() {
 
-	// Register a new setting options.
+	// Register new setting options.
 	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_paths' );
 	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_handles' );
 
 	// Register a new section.
 	add_settings_section(
 		'rt_scripts_optimizer_settings_section',                            // ID.
-		__( 'Script\'s Optimizer Settings', 'RT_Script_Optimizer' ),          // Title.
+		__( 'Script\'s Optimizer Settings', 'RT_Script_Optimizer' ),        // Title.
 		'rt_scripts_optimizer_settings_callback',                           // Callback Function.
 		'rt-scripts-optimizer-settings'                                     // Page.
 	);

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Setting Options page for rt-scripts-optimizer plugin.
+ *
+ * This page will allow users to exclude scripts from being included in script optimizer.
+ *
+ * @package RT_Script_Optimizer
+ */
+
+/**
+ * Custom option's and settings
+ */
+function rt_settings_init() {
+
+	// Register a new setting options.
+	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_paths' );
+	register_setting( 'rt-scripts-optimizer-settings', 'rt_scripts_optimizer_exclude_handles' );
+
+	// Register a new section.
+	add_settings_section(
+		'rt_scripts_optimizer_settings_section',                            // ID.
+		__( 'Script\'s Optimizer Settings', 'RT_Script_Optimizer' ),          // Title.
+		'rt_scripts_optimizer_settings_callback',                           // Callback Function.
+		'rt-scripts-optimizer-settings'                                     // Page.
+	);
+
+	// Register a new field to fetch paths of scripts to exclude.
+	add_settings_field(
+		'rt_scripts_optimizer_path_field',                              // As of WP 4.6 this value is used only internally.
+		__( 'Script path\'s', 'RT_Script_Optimizer' ),                    // Title.
+		'rt_scripts_optimizer_paths_field_callback',                    // Callback Function.
+		'rt-scripts-optimizer-settings',                                // Page.
+		'rt_scripts_optimizer_settings_section',                        // Section.
+	);
+
+	// Register a new field to fetch handles of scripts to exclude.
+	add_settings_field(
+		'rt_scripts_optimizer_handle_field',                            // As of WP 4.6 this value is used only internally.
+		__( 'Script handle\'s', 'RT_Script_Optimizer' ),                  // Title.
+		'rt_scripts_optimizer_handles_field_callback',                  // Callback Function.
+		'rt-scripts-optimizer-settings',                                // Page.
+		'rt_scripts_optimizer_settings_section',                        // Section.
+	);
+}
+
+/**
+ * Register settings to the admin_init action hook.
+ */
+add_action( 'admin_init', 'rt_settings_init' );
+
+
+/**
+ * Section Description callback.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_settings_callback( $args ) {
+	?>
+		<p>
+			<?php esc_html_e( 'Add Scripts you want to exclude from the optimizer by providing it\'s handle or path.', 'RT_Script_Optimizer' ); ?>
+		</p>
+	<?php
+}
+
+/**
+ * Field callback to accept handles to exclude.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_handles_field_callback( $args ) {
+
+	// option value.
+	$handles = get_option( 'rt_scripts_optimizer_exclude_handles' );
+	?>
+
+	<input type="text"
+		id="rt_optimizer_handles"
+		name="rt_scripts_optimizer_exclude_handles"
+		value="<?php echo esc_attr( $handles ); ?>"
+		style="width:80%;"
+	>
+
+	<br>
+
+	<p class = 'description' >
+		<?php esc_html_e( 'Adding script handles to this field will exclude them from optimizer.', 'RT_Script_Optimizer' ); ?>
+	</p>
+	<?php
+}
+
+/**
+ * Field callback to accept paths of scripts to exclude.
+ *
+ * @param array $args arguments passed.
+ */
+function rt_scripts_optimizer_paths_field_callback( $args ) {
+
+	// option value.
+	$paths = get_option( 'rt_scripts_optimizer_exclude_paths' );
+	?>
+
+	<input type="text"
+		id="rt_optimizer_paths"
+		name="rt_scripts_optimizer_exclude_paths"
+		value="<?php echo esc_attr( $paths ); ?>"
+		style="width:80%;"
+	>
+
+	<br>
+
+	<p class = 'description' >
+		<?php esc_html_e( 'Adding script path to this field will exclude them from optimizer.', 'RT_Script_Optimizer' ); ?>
+	</p>
+	<?php
+}
+
+// Add action to add options page.
+add_action( 'admin_menu', 'rt_scripts_optimizer_options_submenu' );
+
+/**
+ * Option page submenu callback.
+ */
+function rt_scripts_optimizer_options_submenu() {
+
+	add_options_page(
+		__( 'rt-scripts Optimizer', 'RT_Script_Optimizer' ),
+		__( 'Script\'s Optimizer', 'RT_Script_Optimizer' ),
+		'manage_options',
+		'rt-scripts-optimizer-settings',
+		'rt_scripts_optimizer_settings_template'
+	);
+
+}
+
+
+/**
+ * Top level menu callback function
+ */
+function rt_scripts_optimizer_settings_template() {
+
+	// check if user can edit the setting.
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	?>
+	<div>
+		<h1>
+			<?php echo esc_html( get_admin_page_title() ); ?>
+		</h1>
+		<br><br>
+		<form action="options.php" method="post">
+			<?php
+
+			// output settings fields for the registered setting "RT_Script_Optimizer".
+			settings_fields( 'rt-scripts-optimizer-settings' );
+
+			// setting sections and their fields.
+			do_settings_sections( 'rt-scripts-optimizer-settings' );
+
+			// output save settings button.
+			submit_button( __( 'Save Settings', 'RT_Script_Optimizer' ) );
+
+			?>
+		</form>
+	</div>
+	<?php
+}

--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -85,6 +85,19 @@ function rt_scripts_handler( $tag, $handle, $src ) {
 		return null;
 	}
 
+	/**
+	 * Checks if the plugin has to be disabled.
+	 *
+	 * Return true if it has to be disabled.
+	 *
+	 * @return bool.
+	 */
+	$disable_rt_optimzer = apply_filters( 'rt_disable_rt_optimzer', false );
+
+	if ( true === $disable_rt_optimzer ) {
+		return $tag;
+	}
+
 	$handles_option_array = explode( ',', get_option( 'rt_scripts_optimizer_exclude_handles' ) );
 	$paths_option_array   = explode( ',', get_option( 'rt_scripts_optimizer_exclude_paths' ) );
 

--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -13,11 +13,21 @@
  * @package RT_Script_Optimizer
  */
 
+// Include settings options page.
+require_once 'includes/settings-page.php';
+
 // Skip if it is WP Backend.
 if ( is_admin() ) {
 	return;
 }
 
+// Variable to store the scripts to be excluded.
+$skip_js = array(
+	'lodash',
+	'wp-dom-ready',
+	'wp-hooks',
+	'wp-i18n',
+);
 /**
  * Head scripts
  */
@@ -58,7 +68,7 @@ add_action( 'wp_footer', 'rt_footer_scripts' );
 
 /**
  * Setting up scripts id and type attribute to identify which scripts to offload to worker thread and reduce main thread execution on load.
- * This funciton changes script attribute for delaying script execution. The scripts having type="text/rtscript" will be passed to Worker thread and 
+ * This funciton changes script attribute for delaying script execution. The scripts having type="text/rtscript" will be passed to Worker thread and
  * then returned back to DOM once user does any interactions with the site by the means of tap, scroll, keypress, or click.
  *
  * @param string $tag    The `<script>` tag for the enqueued script.
@@ -69,38 +79,47 @@ add_action( 'wp_footer', 'rt_footer_scripts' );
  */
 function rt_scripts_handler( $tag, $handle, $src ) {
 
+	global $skip_js;
+
 	if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
 		return null;
 	}
 
-	$script_handle = 1;
+	$handles_option_array = explode( ',', get_option( 'rt_scripts_optimizer_exclude_handles' ) );
+	$paths_option_array   = explode( ',', get_option( 'rt_scripts_optimizer_exclude_paths' ) );
 
-	$priory_handler = [];
+	// Get handle using the paths provided in the settings.
+	foreach ( $paths_option_array as $key => $script_path ) {
+		$script_path = trim( $script_path );
+		if ( empty( $script_path ) ) {
+			continue;
+		}
 
-	$skip_js = [
-		'lodash',
-		'wp-dom-ready',
-		'wp-hooks',
-		'wp-i18n',
-	];
+		if ( strpos( $src, $script_path ) && ! in_array( $handle, $skip_js, true ) ) {
+			array_push( $skip_js, $handle );
+			break;
+		}
+	}
 
-	if ( is_single() ) {
-		$skip_js[] = 'regenerator-runtime';
+	$skip_js = array_unique( array_merge( $skip_js, $handles_option_array ) );
+
+	$array_regenerator_runtime_script = array_search( 'regenerator-runtime', $skip_js, true );
+
+	// If page is single post or page and the script is not in the skip_js array then skip regenerator-runtime script.
+	if ( is_single() && ! $array_regenerator_runtime ) {
+		array_push( $skip_js, 'regenerator-runtime' );
+	} elseif ( $array_regenerator_runtime ) {
+		unset( $skip_js[ $array_regenerator_runtime ] );
 	}
 
 	if ( in_array( $handle, $skip_js, true ) ) {
 		return $tag;
 	}
 
-	if ( in_array( $handle, $priory_handler, true ) ) {
-		$script_handle = 0;
-	}
-
 	// Change the script attributes and id before returning to remove it from main thread.
 	$tag = sprintf(
-		'<script type="text/rtscript" src="%s" data-inline="%s" id="%s"></script>',
+		'<script type="text/rtscript" src="%s" id="%s"></script>',  // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		esc_url( $src ),
-		esc_attr( $script_handle ),
 		$handle . '-js'
 	);
 
@@ -111,7 +130,7 @@ add_filter( 'script_loader_tag', 'rt_scripts_handler', 10, 3 );
 
 
 /**
- * Remove concating all js if site is using nginx-http plugin for files concatination or site is hosted on WordPress VIP. 
+ * Remove concating all js if site is using nginx-http plugin for files concatination or site is hosted on WordPress VIP.
  */
 add_filter( 'js_do_concat', '__return_false' );
 

--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -92,7 +92,7 @@ function rt_scripts_handler( $tag, $handle, $src ) {
 	 *
 	 * @return bool.
 	 */
-	$disable_rt_optimzer = apply_filters( 'rt_disable_rt_optimzer', false );
+	$disable_rt_optimzer = apply_filters( 'disable_rt_scripts_optimizer', false );
 
 	if ( true === $disable_rt_optimzer ) {
 		return $tag;

--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -68,7 +68,7 @@ add_action( 'wp_footer', 'rt_footer_scripts' );
 
 /**
  * Setting up scripts id and type attribute to identify which scripts to offload to worker thread and reduce main thread execution on load.
- * This funciton changes script attribute for delaying script execution. The scripts having type="text/rtscript" will be passed to Worker thread and
+ * This function changes script attribute for delaying script execution. The scripts having type="text/rtscript" will be passed to Worker thread and
  * then returned back to DOM once user does any interactions with the site by the means of tap, scroll, keypress, or click.
  *
  * @param string $tag    The `<script>` tag for the enqueued script.


### PR DESCRIPTION
Add settings page to accept the scripts that have to be excluded from the optimizer.
Two options have been added, that will allow users to add handles and paths ( comma separated ) and the mentioned paths will be excluded from the worker thread and loaded directly.

Attaching screenshot of Settings option page :
![image](https://user-images.githubusercontent.com/53530700/142590599-cb957d04-d29a-4b20-94c0-74745a3b8c68.png)

Further Improvement's :
Add a filter to allow the user to disable `rt-scripts-optimizer`

resolves the issue: #6 

