### PR TITLE
Fix Customizer preview and null return issue for filter

### DIFF
--- a/rt-scripts-optimizer.php
+++ b/rt-scripts-optimizer.php
@@ -21,6 +21,11 @@ if ( is_admin() ) {
 	return;
 }
 
+// Skip if it is customizer preview.
+if ( isset( $_REQUEST['customize_changeset_uuid'] ) ) {
+	return;
+}
+
 // Variable to store the scripts to be excluded.
 $skip_js = array(
 	'lodash',
@@ -82,7 +87,7 @@ function rt_scripts_handler( $tag, $handle, $src ) {
 	global $skip_js;
 
 	if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
-		return null;
+		return $tag;
 	}
 
 	/**


### PR DESCRIPTION
1. Skip the optimizer scripts if it is a customizer preview.
2. `script_loader_tag` filter return shouldn't be `null`, it should be `$tag` instead.